### PR TITLE
Get rid of inline JS in _gap.html.erb

### DIFF
--- a/app/views/kaminari/twitter-bootstrap-3/_gap.html.erb
+++ b/app/views/kaminari/twitter-bootstrap-3/_gap.html.erb
@@ -5,4 +5,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<li class="page gap disabled"><a href="#" onclick="return false;"><%= raw(t 'views.pagination.truncate') %></a></li>
+<li class="page gap disabled"><a><%= raw(t 'views.pagination.truncate') %></a></li>


### PR DESCRIPTION
This fixes a CSP violation

After removing the `onclick` attribute the link still looks and behaves exactly the same:
![image](https://user-images.githubusercontent.com/5732023/95859727-54c23500-0d5f-11eb-94a0-8cf639f34226.png)

part of https://github.com/Leadfeeder/issue-tracker/issues/15450